### PR TITLE
Ubuntu Image throwing cert errors - Rehosted on Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/alpine
 EXPOSE 5900:5900
 RUN apk update 
-# Add in Firefox, Ratpoison (for a minimal VM), and enough fonts to handle
+# Add in Firefox ESR, Ratpoison (for a minimal VM), and enough fonts to handle
 # nearly all web-based applications. Traditional X11 fonts have been added
 # to support xterm. 
 RUN apk add bash font-terminus font-inconsolata font-dejavu font-noto-all \
@@ -13,7 +13,7 @@ RUN apk add bash font-terminus font-inconsolata font-dejavu font-noto-all \
             font-micro-misc font-misc-misc font-mutt-misc \
             font-schumacher-misc font-sony-misc font-sun-misc font-unifont \
             font-bitstream-100dpi font-bitstream-75dpi font-bitstream-type1 \
-            xterm firefox ratpoison tigervnc shadow
+            xterm firefox-esr ratpoison tigervnc shadow
 RUN useradd -m vncfox
 ADD xinitrc /home/vncfox/.xinitrc
 RUN chmod +x /home/vncfox/.xinitrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,33 @@
-FROM ubuntu
+FROM docker.io/alpine
 EXPOSE 5900:5900
-RUN apt update -y
-RUN apt install -y software-properties-common
-RUN add-apt-repository ppa:mozillateam/ppa
-RUN apt install -y firefox-esr tightvncserver ratpoison xterm
+RUN apk update 
+# Add in Firefox, Ratpoison (for a minimal VM), and enough fonts to handle
+# nearly all web-based applications. Traditional X11 fonts have been added
+# to support xterm. 
+RUN apk add bash font-terminus font-inconsolata font-dejavu font-noto-all \
+            font-awesome font-liberation font-dejavu font-xfree86-type1 \
+            font-freefont font-adobe-100dpi font-ibm-type1 font-mutt-misc \
+            font-adobe-75dpi font-adobe-source-code-pro font-xfree86-type1  \
+            font-adobe-utopia-100dpi font-adobe-utopia-75dpi \
+            font-adobe-utopia-type1 font-cursor-misc font-dec-misc \
+            font-micro-misc font-misc-misc font-mutt-misc \
+            font-schumacher-misc font-sony-misc font-sun-misc font-unifont \
+            font-bitstream-100dpi font-bitstream-75dpi font-bitstream-type1 \
+            xterm firefox ratpoison tigervnc shadow
 RUN useradd -m vncfox
-ADD xsession /home/vncfox/.xsession
-RUN mkdir /home/vncfox/.vnc
+ADD xinitrc /home/vncfox/.xinitrc
+RUN chmod +x /home/vncfox/.xinitrc
+ADD vncserver-config-defaults /etc/tigervnc/vncserver-config-defaults
+RUN chown vncfox /etc/tigervnc/vncserver-config-defaults
+ADD vncserver.users /etc/tigervnc/vncserver.users
+ADD xsession.desktop /usr/share/xsessions
 RUN mkdir /home/vncfox/.mozilla
+RUN mkdir -p /home/vncfox/.config/tigervnc
+RUN sh -c 'echo vncfox | vncpasswd -f > /home/vncfox/.config/tigervnc/passwd'
+RUN chmod 600 /home/vncfox/.config/tigervnc/passwd
 RUN chown -R vncfox /home/vncfox
 ADD init /init
 USER vncfox
-RUN sh -c 'echo vncfox | vncpasswd -f > /home/vncfox/.vnc/passwd'
-RUN chmod 600 /home/vncfox/.vnc/passwd
 ENV USER=vncfox
 ENV WIDTH=1024
 ENV HEIGHT=768

--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ http://osarchive.org/apps/vnc/tight/ports
 This can be changed to use other modifier keys as part of the command line
 options with the  -ShortcutModifiers option. It only accepts modifer keys like 
 Ctrl,Shift,Alt,Win/Super. To set it up to use Control-Shift, use the following 
-argument. 
-  * -ShortcutModifiers=Ctrl,Shift *
+argument.
+
+
+*-ShortcutModifiers=Ctrl,Shift*
 
 ## Firefox Customization
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ I typically bind mount a folder exported via NFS to `/home/vncfox/Downloads`.
 
 ## Resolution
 
-TightVNC 1.3 doesn't support remote resize. Only a fixed resolution is allowed. The default resolution is 1024x768. This is because I mostly work on workstations with 1280x1024 and I want a smaller window. However you can set custom resolution by using `WIDTH` and `HEIGHT` env variables. In future the server side may be upgraded to TigerVNC which allows remote resize.
+The default resolution is 1024x768. This is because I mostly work on workstations with 1280x1024 and I want a smaller window. However you can set custom resolution by using `WIDTH` and `HEIGHT` env variables. The server side runs TigerVNC which allows remote resizing.
 
 ```sh
 docker volume create vncfox

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This can be changed to use other modifier keys as part of the command line
 options with the  -ShortcutModifiers option. It only accepts modifer keys like 
 Ctrl,Shift,Alt,Win/Super. To set it up to use Control-Shift, use the following 
 argument. 
-  *-ShortcutModifiers=Ctrl,Shift*
+  * -ShortcutModifiers=Ctrl,Shift *
 
 ## Firefox Customization
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ http://osarchive.org/apps/vnc/tight/ports
 - F8  - opens TightVNC menu, clipboard transfer etc
 - F11 - FireFox full screen mode
 
+*Note:* As of TigerVNC Client 1.16.0, the default menu shortcut is Ctrl-Alt-M.
+This can be changed to use other modifier keys as part of the command line
+options with the  -ShortcutModifiers option. It only accepts modifer keys like 
+Ctrl,Shift,Alt,Win/Super. To set it up to use Control-Shift, use the following 
+argument. 
+  *-ShortcutModifiers=Ctrl,Shift*
+
 ## Firefox Customization
 
 Better scrollbars:

--- a/init
+++ b/init
@@ -1,5 +1,18 @@
 #!/bin/bash
-while true; do
-	pgrep Xtightvnc >/dev/null || { rm -f /tmp/.X0-lock /tmp/.X11-unix/X0; tightvncserver -geometry ${WIDTH}x${HEIGHT} :0; }
-	sleep 10
+
+grep -q "${WIDTH}x${HEIGHT}" /etc/tigervnc/vncserver-config-defaults
+if [[ $? -ne 0 ]];
+then
+  echo "geometry=${WIDTH}x${HEIGHT}" >> /etc/tigervnc/vncserver-config-defaults
+fi
+rm -rf /tmp/.X0-lock /tmp/.X11-unix
+while true
+do
+  pgrep Xvnc >/dev/null
+  if [[ $? -ne 0 ]];
+  then 
+    vncserver :0
+  else
+    sleep 10
+  fi
 done

--- a/vncserver-config-defaults
+++ b/vncserver-config-defaults
@@ -1,0 +1,17 @@
+## Default settings for VNC servers started by the vncserver service
+#
+# Any settings given here will override the builtin defaults, but can
+# also be overriden by ~/.config/tigervnc/config and vncserver-config-mandatory.
+#
+# See HOWTO.md and the following manpages for more details:
+#     vncsession(8) Xvnc(1)
+#
+# Several common settings are shown below. Uncomment and modify to your
+# liking.
+session=xsession
+securitytypes=vncauth
+# session=gnome
+# securitytypes=vncauth,tlsvnc
+# geometry=2000x1200
+# localhost
+# alwaysshared

--- a/vncserver.users
+++ b/vncserver.users
@@ -1,0 +1,8 @@
+# TigerVNC user assignment
+#
+# This file assigns users to specific VNC display numbers.
+# The syntax is <display>=<username>. E.g.:
+#
+# :2=andrew
+# :3=lisa
+:0=vncfox

--- a/xinitrc
+++ b/xinitrc
@@ -1,0 +1,5 @@
+ratpoison &
+while true
+do 
+  firefox
+done

--- a/xinitrc
+++ b/xinitrc
@@ -1,5 +1,5 @@
 ratpoison &
 while true
 do 
-  firefox
+  firefox-esr
 done

--- a/xsession
+++ b/xsession
@@ -1,2 +1,0 @@
-ratpoison&
-while true; do firefox-esr ; done

--- a/xsession.desktop
+++ b/xsession.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Encoding=UTF-8
+Type=XSession
+Exec=/home/vncfox/.xinitrc
+Name=Xsession
+Comment=Xinit test


### PR DESCRIPTION
Rehosted on Alpine Linux because Ubuntu's image was throwing cert issues with their expiring repositories.
This has also been moved to TigerVNC instead of TightVNC.
The older .vnc paths have been moved to .config/tigervnc to match what TigerVNC is now expecting for its config file paths.
